### PR TITLE
Requirement

### DIFF
--- a/src/app.lisp
+++ b/src/app.lisp
@@ -37,7 +37,7 @@
 
 (cl-syntax:use-syntax :annot)
 
-(defvar *default-requirements-map*
+(defun default-requirements-map ()
   (let ((hash (make-hash-table :test 'eq)))
     (setf (gethash :accept hash)
           (lambda (types)
@@ -55,7 +55,7 @@
   ((mapper :initform (make-mapper)
            :accessor mapper)
    (requirements :type hash-table
-                 :initform *default-requirements-map*
+                 :initform (default-requirements-map)
                  :accessor app-requirements))
   (:documentation "Base class for Ningle Application. All Ningle Application must inherit this class."))
 

--- a/t/requirements.lisp
+++ b/t/requirements.lisp
@@ -10,7 +10,7 @@
                 :http-request))
 (in-package :ningle-test.requirements)
 
-(plan 4)
+(plan 5)
 
 (defvar *app*)
 (setf *app* (make-instance '<app>))
@@ -69,5 +69,8 @@
                              :user-agent "Songbird/2.2.0")
       (is status 200)
       (is body "Songbird ver 2.2.0"))))
+
+(isnt (ningle.app::app-requirements (make-instance '<app>))
+      (ningle.app::app-requirements (make-instance '<app>)))
 
 (finalize)


### PR DESCRIPTION
`*default-requirements-map*` is used for `:initform` of `app-requirements` of `<app>`,
and it causes the issue like
```Lisp
(ql:quickload 'ningle)

(defclass <alfa> (ningle:<app>) ())
(defclass <bravo> (ningle:<app>) ())

(defvar *charlie* (make-instance '<alfa>))
(defvar *delta* (make-instance '<bravo>))

(setf (ningle:requirement *charlie* :echo)
      (lambda () (pprint "charlie")))

(setf (ningle:requirement *delta* :echo)
      (lambda () (pprint "delta")))

(funcall (ningle:requirement *charlie* :echo))
;; => "delta"
(funcall (ningle:requirement *delta* :echo))
;; => "delta"
```
.