### PR TITLE
Use symbols for URL params in README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -62,10 +62,10 @@ Route pattern may contain "keyword" to put the value into the argument.
 ```common-lisp
 (setf (ningle:route *app* "/hello/:name")
       #'(lambda (params)
-          (format nil "Hello, ~A" (cdr (assoc "name" params :test #'string=)))))
+          (format nil "Hello, ~A" (cdr (assoc :name params)))))
 ```
 
-The above controller will be invoked when you access to "/hello/Eitaro" or "/hello/Tomohiro", and then `(cdr (assoc "name" params :test #'string=))` will be "Eitaro" and "Tomohiro".
+The above controller will be invoked when you access to "/hello/Eitaro" or "/hello/Tomohiro", and then `(cdr (assoc :name params))` will be "Eitaro" and "Tomohiro".
 
 Route patterns may also contain "wildcard" parameters. They are accessible by `(assoc :splat params)`.
 


### PR DESCRIPTION
Hello,

This seems like a nice framework. I am a Common Lisp newbie and am trying to use Ningle. I think the README is out of date, because when I use a named URL parameter like in `"/greet/:name"`, I can only access the value with this code:

```lisp
(cdr (assoc :name params))
```

This code does not seem to work:

```lisp
(cdr (assoc "name" params :test #'string=))
```

I updated the README to show the symbol code. I hope it is useful! Thank you for your work on this library!