### PR TITLE
Omit headers & field metas only in multipart/form-dasta

### DIFF
--- a/src/app.lisp
+++ b/src/app.lisp
@@ -14,7 +14,8 @@
                 :request-headers
                 :request-method
                 :request-path-info
-                :request-parameters)
+                :request-parameters
+                :request-content-type)
   (:import-from :lack.response
                 :response-body
                 :response-status
@@ -127,9 +128,11 @@
                                             (lambda (params)
                                               (funcall controller
                                                        (append (mapc (lambda (pair)
-                                                                       ;; Omit headers & field-metas in multipart/form-data.
-                                                                       (when (consp (cdr pair))
-                                                                         (rplacd pair
+                                                                                 ;; Omit headers & field-metas only in multipart/form-data.
+                                                                       (and (consp (cdr pair))
+                                                                            (string-equal (request-content-type *request*)
+                                                                                          "multipart/form-data")
+                                                                            (rplacd pair
                                                                                  (first (cdr pair)))))
                                                                      (request-parameters *request*))
                                                                (loop for (k v) on params by #'cddr


### PR DESCRIPTION
Since I saw this two issues which are the same:

[https://github.com/fukamachi/ningle/issues/22](issue-1)
[https://github.com/fukamachi/ningle/issues/24](issue-21)

I thik that the best way is to check if the body is multipart/form-data, from here

[http://www.iana.org/assignments/media-types/media-types.xhtml](media-types)

Maybe should be use match against regular expression or substring, I use string-equal in order to be case-insentive as request headers are, and I do not feel that to add more complexity will be good for this purpouse

[http://stackoverflow.com/questions/5258977/are-http-headers-case-sensitive](stackoverflow-headers)

I hope this helps