### PR TITLE
Update unit tests for newer versions of clack.

### DIFF
--- a/tests/main.lisp
+++ b/tests/main.lisp
@@ -88,7 +88,7 @@
 
 (flet ((localhost (path)
          (format nil "http://localhost:~D~A" clack.test:*clack-test-port* path)))
-  (clack.test:subtest-app "Test"
+  (clack.test:testing-app "Test"
       *app*
     (is (drakma:http-request (localhost "/")) "Hello, World!")
     (loop for url in '("/hello.json" "/hello2.json")
@@ -129,7 +129,7 @@
         (declare (ignore params))
         (prin1-to-string (class-name (class-of *request*)))))
 
-(clack.test:subtest-app "Test 2"
+(clack.test:testing-app "Test 2"
     *app2*
   (is (drakma:http-request (format nil "http://localhost:~D/request-class"
                                    clack.test:*clack-test-port*))
@@ -142,7 +142,7 @@
   (setf (response-body *response*) "Page not found")
   nil)
 
-(clack.test:subtest-app "Test 3"
+(clack.test:testing-app "Test 3"
     *app2*
   (is (drakma:http-request (format nil "http://localhost:~D/404-page-not-found"
                                    clack.test:*clack-test-port*))

--- a/tests/requirements.lisp
+++ b/tests/requirements.lisp
@@ -3,7 +3,7 @@
         #:ningle
         #:prove)
   (:import-from #:clack.test
-                #:subtest-app
+                #:testing-app
                 #:*clack-test-port*)
   (:import-from #:drakma
                 #:http-request))
@@ -29,7 +29,7 @@
 
 (flet ((localhost (path)
          (format nil "http://localhost:~D~A" clack.test:*clack-test-port* path)))
-  (clack.test:subtest-app "Test 1"
+  (clack.test:testing-app "Test 1"
       *app*
     (multiple-value-bind (body status)
         (drakma:http-request (localhost "/")
@@ -58,7 +58,7 @@
 
 (flet ((localhost (path)
          (format nil "http://localhost:~D~A" clack.test:*clack-test-port* path)))
-  (clack.test:subtest-app "Test 2"
+  (clack.test:testing-app "Test 2"
       *app*
     (is (nth-value 1
                    (drakma:http-request (localhost "/")))


### PR DESCRIPTION
Clack has replaced CLACK.TEST:SUBTEST-APP with CLACK.TEST:TESTING-APP
as part of the switch from prove to rove. Update the tests here to
match accordingly (this will not be backwards-compatible with older
versions of clack).