### PR TITLE
Update (cl-syntax:use-syntax :annot) -> (annot:enable-annot-syntax)

### DIFF
--- a/app.lisp
+++ b/app.lisp
@@ -36,7 +36,7 @@
                 #:delete-from-plist))
 (in-package #:ningle/app)
 
-(cl-syntax:use-syntax :annot)
+(annot:enable-annot-syntax)
 
 (defun default-requirements-map ()
   (let ((hash (make-hash-table :test 'eq)))

--- a/context.lisp
+++ b/context.lisp
@@ -3,7 +3,7 @@
   (:use #:cl))
 (in-package #:ningle/context)
 
-(cl-syntax:use-syntax :annot)
+(annot:enable-annot-syntax)
 
 @export
 (defvar *context* nil


### PR DESCRIPTION
This pull request updates the use of cl-annot.

Older versions of cl-annot cause the next problem when I try to load a system that depends on it:
```
debugger invoked on a EDITOR-HINTS.NAMED-READTABLES:READER-MACRO-CONFLICT in thread
#<THREAD tid=89313 "main thread" RUNNING {10013F0073}>:
  Reader macro conflict while trying to merge the dispatch macro characters #\#
  #\R from #<NAMED-READTABLE CL-ANNOT::SYNTAX {1002923643}> into
  #<READTABLE {10064CC433}>.

Type HELP for debugger help, or (SB-EXT:EXIT) to exit from SBCL.

restarts (invokable by number or by possibly-abbreviated name):
  0: [CONTINUE                     ] Overwrite #\# in #<NAMED-READTABLE :CURRENT {10064CC433}>.
  1: [TRY-RECOMPILING              ] Recompile lisp and try loading it again
  2: [RETRY                        ] Retry
                                     loading FASL for #<CL-SOURCE-FILE "ningle/context" "lisp">.
  3: [ACCEPT                       ] Continue, treating
                                     loading FASL for #<CL-SOURCE-FILE "ningle/context" "lisp">
                                     as having been successful.
  4:                                 Retry ASDF operation.
  5: [CLEAR-CONFIGURATION-AND-RETRY] Retry ASDF operation after resetting the
                                     configuration.
  6:                                 Retry ASDF operation.
  7:                                 Retry ASDF operation after resetting the
                                     configuration.
  8: [ABORT                        ] Give up on "fql"
  9: [REGISTER-LOCAL-PROJECTS      ] Register local projects and try again.
 10:                                 Exit debugger, returning to top level.

(EDITOR-HINTS.NAMED-READTABLES:MERGE-READTABLES-INTO #<READTABLE {10064CC433}> #<NAMED-READTABLE CL-ANNOT::SYNTAX {1002923643}>)
   source: (CHECK-READER-MACRO-CONFLICT FROM TO CHAR SUBCHAR)

```