### PR TITLE
Fix: remove unused &rest parameter

### DIFF
--- a/route.lisp
+++ b/route.lisp
@@ -18,7 +18,7 @@
    (controller :initarg :controller
                :accessor route-controller)))
 
-(defmethod initialize-instance :after ((route ningle-route) &rest initargs &key requirements-map requirements &allow-other-keys)
+(defmethod initialize-instance :after ((route ningle-route) &key requirements-map requirements &allow-other-keys)
   (when requirements-map
     (setf (route-compiled-requirements route)
           (compile-requirements requirements-map requirements))))


### PR DESCRIPTION
This fixes a style-warning for unused parameter.

Now there are no style warnings on sbcl 2.4.3.
Also test suites are still working.